### PR TITLE
P3732R1 (numeric ranges algorithms)

### DIFF
--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -617,9 +617,12 @@ We do not propose `adjacent_transform` for the reasons described above.
 #### `partial_sum`
 
 The `partial_sum` algorithm combines elements sequentially, from left to right.
-The Standard Library already has `fold_left*` algorithms with this behavior.
-[@P3351R2], "`views::scan`," proposes a view with the same left-to-right behavior;
-it is currently in SG9 (Ranges Study Group) review.
+It behaves like an order-constrained version of `inclusive_scan`.
+
+Our proposal focuses on algorithms that permit reordering binary operations.
+For users who want an order-constrained partial sum,
+[@P3351R2], "`views::scan`," proposes a view with the same left-to-right behavior.
+This paper is currently in SG9 (Ranges Study Group) review.
 
 Users of `partial_sum` who are not concerned about the order of operations
 can call the `inclusive_scan` algorithm (proposed here) instead.

--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -774,11 +774,22 @@ requirement for the non-parallel algorithms we propose. This leaves us with two 
 
 * (multipass) forward ranges.
 
-The various reduction and scan algorithms we propose can combine the elements of the range in any order. For this reason,
-we make the non-parallel algorithms take (multipass) forward ranges, even though this is not consistent with the existing
-non-parallel `<numeric>` algorithms. If users have single-pass iterators, they should just call one of the `fold_*`
-algorithms, or use the `views::scan` proposed elsewhere. This has the benefit of letting us specify `ranges::reduce`
-to return just the value. We don't propose a separate algorithm `reduce_with_iter`, as we explain [in the relevant section](#no-reduce-with-iter).
+We believe there is no value in `*reduce` and `*_scan` taking single-pass input ranges,
+because these algorithms can combine the elements of their input range(s) in any order.
+Suppose that an algorithm had that freedom to rearrange operations,
+yet was constrained to read the input ranges exactly once, in left-to-right order.
+The only way such an algorithm could exploit that freedom
+would be for it to copy the input ranges into temporary storage.
+Users who want that could just copy the input ranges into contiguous storage themselves.
+
+For this reason, we make the non-parallel algorithms take (multipass) forward ranges,
+even though this is not consistent with the existing non-parallel `<numeric>` algorithms.
+If users have single-pass iterators, they should just call one of the `fold_*` algorithms,
+or use the `views::scan` proposed in [@P3351R2].
+This has the benefit of letting us specify `ranges::reduce` to return just the value.
+We don't propose a separate `reduce_with_iter` algorithm
+to return both the value and the one-past-the-input iterator,
+as we explain [in the relevant section](#no-reduce-with-iter).
 
 ## Constexpr parallel algorithms?
 

--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -56,6 +56,10 @@ R0 is the original draft prepared before the June 2025 Sofia WG21 meeting.  SG1 
 
 - Revise non-wording sections
 
+    - Explain `reduce_into` and `transform_reduce_into`
+
+    - Show different designs for specifying identity value
+
 # What we propose
 
 We propose `ranges` overloads (both parallel and non-parallel) of the following algorithms:

--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -1348,12 +1348,12 @@ We would like to hear feedback from SG9 on their preferred design.
 In this section, we focus on `ranges::reduce`'s design.  The discussion here applies generally to the other algorithms we
 propose.
 
-### No default parameters
+### No default binary operation or initial value
 
 Section 5.1 of [@P2760R1] states:
 
-> One thing is clear: `ranges::reduce` should *not* take a default binary operation *nor* a default initial [value]
-> parameter. The user needs to supply both.
+> One thing is clear: `ranges::reduce` should *not* take a default binary operation
+> *nor* a default initial [value] parameter. The user needs to supply both.
 
 This motivates the following convenience wrappers:
 
@@ -1361,8 +1361,9 @@ This motivates the following convenience wrappers:
 - `ranges::product(r)` for `ranges::reduce` with `init = range_value_t<R>(1))` and `multiplies{}` as the reduce operation;
   and
 - `ranges::dot(x, y)` for binary `ranges::transform_reduce` with `init = T()` where
-  `T = decltype(declval<range_value_t<X>>() * declval<range_value_t<Y>>())`, `multiplies{}` as the transform operation,
-  and `plus{}` as the reduce operation.
+  `T = decltype(declval<range_value_t<X>>() * declval<range_value_t<Y>>())`,
+  `multiplies{}` is the transform operation,
+  and `plus{}` is the reduce operation.
 
 One argument *for* a default initial value in `std::reduce` is that `int` literals like `0` or `1` do not behave in the
 expected way with a sequence of `float` or `double`.  For `ranges::reduce`, however, making its return value type imitate

--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -66,14 +66,18 @@ We propose `ranges` overloads (both parallel and non-parallel) of the following 
 
 * `exclusive_scan` and `transform_exclusive_scan`.
 
+These correspond to existing algorithms with the same names in the `<numeric>` header.
+Therefore, we called them "numeric range(s) algorithms."
+
 We also propose adding parallel and non-parallel convenience wrappers:
 
 * `ranges::sum` and `ranges::product` for special cases of `reduce` with addition and multiplication, respectively; and
 
 * `ranges::dot` for the special case of binary `transform_reduce` with transform `multiplies{}` and reduction `plus{}`.
 
-The following sections explain why we propose these algorithms and not others.  This relates to other aspects of the design
-besides algorithm selection, such as whether to include optional projection parameters.
+The following sections explain why we propose these algorithms and not others.
+This relates to other aspects of the design besides algorithm selection,
+such as whether to include optional projection parameters.
 
 # Design
 

--- a/parallel_algorithms/P3732/numeric_ranges_algorithms.md
+++ b/parallel_algorithms/P3732/numeric_ranges_algorithms.md
@@ -38,6 +38,24 @@ We propose `ranges` algorithm overloads (both parallel and non-parallel) for the
 
 * Abhilash Majumder (NVIDIA)
 
+# Revision history
+
+## R0 to be submitted 2025-07-15
+
+R0 is the original draft prepared before the June 2025 Sofia WG21 meeting.  SG1 reviewed this draft during the Sofia meeting with the following feedback.
+
+- SG1 agrees (via poll 4/5/1/0/0) that users should have a way to specify an identity value.  SG1 asks whether there is any need to specify this as a compile-time value, or whether a run-time-only interface would suffice.  One concern is the potential cost of broadcasting an identity value at run time to all threads, versus initializing each thread's accumulator to a value known at compile time.
+
+- SG1 has no objection to adding `transform_*` variants of algorithms.
+
+- SG1 asks us to add `reduce_into` and `transform_reduce_into` (via poll 4/4/0/0/0), that is, versions of `reduce` and `transform_reduce` that write the reduction result to an output range of one element.  (We asked SG1 to take this poll because LEWG rejected an analogous design for std::linalg reduction-like algorithms such as dot product and norms.)
+
+- SG1 members would like separate proposals on fixing _`movable-box`_ trivial copyability, and fixing performance issues with views in general.
+
+## R1 in preparation
+
+- Revise non-wording sections
+
 # What we propose
 
 We propose `ranges` overloads (both parallel and non-parallel) of the following algorithms:


### PR DESCRIPTION
@rarutyun @akukanov 

Update non-wording sections

* Explain `reduce_into` and `transform_reduce_into`
* Show different designs for specifying an identity value
* Fix grammar and wording

This incorporates design discussions in https://github.com/rarutyun/iso_cpp_papers/issues/31 .